### PR TITLE
Adding OTA via DJANGO

### DIFF
--- a/BLECarPiZeroW/ccserver/administration/urls.py
+++ b/BLECarPiZeroW/ccserver/administration/urls.py
@@ -1,7 +1,8 @@
 from django.conf.urls import url
 
-from administration.views import ServiceController
+from administration.views import ServiceController, ota
 
 urlpatterns = [
     url(r'^service/$', ServiceController.as_view(), name="speed-ctrl"),
+    url(r'^ota/', ota, name="ota-view")
 ]

--- a/BLECarPiZeroW/ccserver/ccserver/settings.py
+++ b/BLECarPiZeroW/ccserver/ccserver/settings.py
@@ -57,7 +57,9 @@ ROOT_URLCONF = 'ccserver.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [
+            os.path.join(BASE_DIR, 'templates/')
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/BLECarPiZeroW/ccserver/ccserver/urls.py
+++ b/BLECarPiZeroW/ccserver/ccserver/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     url(r'^sensor/', include('sensors.urls')),
     url(r'^control/', include('controls.urls')),
     url(r'^administration/', include('administration.urls')),
+    url('^accounts/', include('django.contrib.auth.urls')),
 ]

--- a/BLECarPiZeroW/ccserver/templates/over_the_air.html
+++ b/BLECarPiZeroW/ccserver/templates/over_the_air.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Over the air update</title>
+    <style>
+        input {
+            display: block;
+        }
+
+        input[type=radio] {
+            display: inline;
+        }
+
+        .center {
+            padding: 1rem;
+            width: 50%;
+            margin-left: 10%;
+            margin-right: auto;
+        }
+    </style>
+</head>
+<body>
+<h1>Over the Air Update Utility</h1>
+<p>Warning! This feature is dangerous and could provoke irreversible damages.</p>
+<p>Filename must mach module name!</p>
+<form class="center" method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {{ form }}
+    <br><br>
+    <input type="submit" value="Submit"/>
+</form>
+</body>
+</html>


### PR DESCRIPTION
Consider the GO implementation as deprecated. I've added the a Django implementation instead.

In order for the view to work you'll need to be logged in first, via /admin.

Then head to administation/ota and do your thing.
A superuser can be created by running the following command in the server directory:
`python3 manage.py createsuperuser`